### PR TITLE
Modify thresdhold to 0.5

### DIFF
--- a/SmileDetector/ViewController.swift
+++ b/SmileDetector/ViewController.swift
@@ -131,7 +131,7 @@ extension ViewController: VideoCaptureDelegate {
                         return
                     }
 
-                    if let faceArray = faces, faceArray.count > 0 && faceArray[0].smilingProbability > 0.6 {
+                    if let faceArray = faces, faceArray.count > 0 && faceArray[0].smilingProbability > 0.5 {
                         DispatchQueue.main.async {
                             self.emitterLayer.birthRate = Float(faceArray[0].smilingProbability * 3)
                             self.flagView.isHidden = false


### PR DESCRIPTION
In the blog post snippet we use 0.5 instead of 0.6 and I have the feeling that sometimes it is not detecting subtle smiles so I think it is better to use 0.5.   Did you have different results in your tests and that's why you modifieD?